### PR TITLE
fix: apply best practices for order_name (#2)

### DIFF
--- a/models/ButterfliesModel.js
+++ b/models/ButterfliesModel.js
@@ -34,10 +34,12 @@ const ButterfliesModel = db_connection.define(
         },
       },
     },
-    order_name: {
+    order: {
+      // 1.ORDER Este es el nombre que usará la API y el frontend
       type: DataTypes.STRING(50),
       allowNull: false,
       defaultValue: "Lepidoptera",
+      field: "order_name", // 2.ORDER_NAME Este es el nombre REAL de la columna en la base de datos
       validate: {
         isIn: {
           args: [["Lepidoptera"]],


### PR DESCRIPTION
## Contexto del Problema
Se detectó una inconsistencia de nombres entre el frontend y el backend para el campo que define el orden taxonómico de la mariposa.

Frontend: Esperaba y enviaba un campo llamado order.

Backend (Base de Datos): Utilizaba una columna llamada order_name.

La razón de usar order_name en la base de datos es crucial: ORDER es una palabra reservada en SQL (usada en ORDER BY), y nombrarla así directamente es una mala práctica que puede causar errores y fallos en las consultas.

## Solución Implementada
Para resolver este conflicto de la forma más profesional, sin necesidad de modificar el frontend y manteniendo la integridad de nuestra base de datos, se implementó un alias en el modelo de Sequelize.

Se utilizó la propiedad field en la definición del modelo para desacoplar el nombre del campo en la API del nombre de la columna en la base de datos.

Cambio en models/ButterfliesModel.js:


```
order: {
  // Este es el nombre que la API expone al exterior (frontend)
  type: DataTypes.STRING(50),
  field: 'order_name', // Este es el nombre real de la columna en la BBDD
  allowNull: false,
  defaultValue: "Lepidoptera",
  // ... validaciones
},
```

## Resultado
Con este cambio, logramos lo mejor de ambos mundos:

Consistencia en la API: La API ahora acepta y devuelve el campo order de manera transparente, cumpliendo con el contrato esperado por el frontend.

Base de Datos Robusta: La estructura de la base de datos se mantiene segura y correcta, utilizando order_name y evitando conflictos con palabras reservadas de SQL.

Código Desacoplado: El modelo de datos ahora sirve como una capa de traducción, haciendo nuestra aplicación más flexible y mantenible.